### PR TITLE
Updates to enable to miner to compile and run on Linux-x64 2021 version of Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signum-miner"
-version = "1.8.0"
+version = "1.8.1"
 license = "GPL-3.0"
 authors = ["signum-network, forked from PoC Consortium"]
 description = """
@@ -11,7 +11,7 @@ repository = "https://github.com/signum-network/signum-miner"
 documentation = "https://github.com/signum-network/signum-miner"
 keywords = ["poc", "miner", "rust","cryptocurrency"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [features]
 simd = []
@@ -31,7 +31,7 @@ libc = "0.2"
 log = "0.4"
 log4rs = { version = "0.8", features = ["rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"] }
 num_cpus = "1.9"
-ocl-core = { version = "0.11.1", optional = true } 
+ocl-core = { version = "0.11.5", optional = true } 
 pbr = "1.0.1"
 rand = "0.6"
 rayon = "1.0"
@@ -43,7 +43,6 @@ stopwatch = "0.0.7"
 tokio = "0.1"
 url = "1.7"
 page_size = "0.4.1"
-aligned_alloc = "0.1"
 reqwest = { version = "0.9.9", default-features = false, features = ["rustls-tls"] }
 bytes = "0.4.11"
 url_serde = "0.2"

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -137,11 +137,8 @@ pub struct CpuBuffer {
 
 impl CpuBuffer {
     pub fn new(buffer_size: usize) -> Self {
-        let pointer = aligned_alloc::aligned_alloc(buffer_size, page_size::get());
-        let data: Vec<u8>;
-        unsafe {
-            data = Vec::from_raw_parts(pointer as *mut u8, buffer_size, buffer_size);
-        }
+        let data = vec![0u8; buffer_size]; // Create a vector with the specified size, initialized to zero
+
         CpuBuffer {
             data: Arc::new(Mutex::new(data)),
         }


### PR DESCRIPTION
Changes to the miner.rs file:
- Update the use of the alligned_alloc crate to use a memory safe alternative

Changes to the shabal256.rs file:
- Remove from_raw_parts to use a pre-allocated vector allowing us to chunk it into 4 without having to use pointers and unsafe calls

Changes to the Cargo.toml file:
- Update the version as it's worth a new release
- Remove no longer needed alligned_alloc crate
- Bumped some crate versions